### PR TITLE
Worked on release 0.2.44 tickets

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,15 @@
+v0.2.44
+	Enhancements:
+		- Added sila_available_balance and sila_pending_balance in the response of /get_wallet.  
+		- Added new input value for processing_type "WIRE" and  a optional input "mock_wire_account_name" in /redeem_sila.
+		- Added IMAD, OMAD, provider_tx_id and provider_status fields in the response of /get_transactions. 
+		- Added provider_status field in timeline object in the response of /get_transactions.
+		- Added new processing type "WIRE" in input field in search_filters in /get_transactions.
+		
+	New Features:
+		- Added support for /approve_wire endpoint.
+		- Added support for /mock_wire_out_file endpoint.
+
 v0.2.43
 	Enhancements:
 		Added "sec_code" string field to the response in /get_transactions.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "name": "sila-sdk-javascript",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "main": "lib/index.js",
   "directories": {
     "lib": "lib",

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ const signOpts = (opts, key, businessPrivateKey) => {
   const options = lodash.cloneDeep(opts);
   if (opts.body.header) {
     options.headers = {};
-    options.headers['User-Agent'] = 'SilaSDK-node/0.2.43';
+    options.headers['User-Agent'] = 'SilaSDK-node/0.2.44';
     const bodyString = JSON.stringify(options.body);
     options.headers.authsignature = sign(bodyString, appKey);
     if (key) options.headers.usersignature = sign(bodyString, key);
@@ -577,6 +577,7 @@ const issueSila = (
  * @param {String} cardName  The nickname of the card to debit from. Optional, OR "account_name": "default", never both.
  * @param {String} sourceId source account id to debit from (optional)
  * @param {String} destinationId destination account id for credit (optional)
+ * @param {String} mockWireAccountName Optional with value of "mock_account_success" or "mock_account_fail"
  */
 const redeemSila = (
   amount,
@@ -589,6 +590,7 @@ const redeemSila = (
   cardName = undefined,
   sourceId = undefined,
   destinationId = undefined,
+  mockWireAccountName = undefined,
 ) => {
   const fullHandle = getFullHandle(handle);
   const body = setHeaders({ header: {} }, fullHandle);
@@ -612,6 +614,10 @@ const redeemSila = (
   if (descriptor) body.descriptor = descriptor;
   if (businessUuid) body.business_uuid = businessUuid;
   body.processing_type = processingType;
+
+  if (mockWireAccountName) body.mock_wire_account_name = mockWireAccountName;
+
+  
 
   return makeRequest('redeem_sila', body, privateKey);
 };
@@ -1662,7 +1668,7 @@ const closeVirtualAccount = (userHandle, userPrivateKey, virtualAccountId, accou
  * @param {Object} payload
  * @returns
  */
- const createTestVirtualAccountAchTransaction = (userHandle, userPrivateKey, payload={}) => {
+const createTestVirtualAccountAchTransaction = (userHandle, userPrivateKey, payload={}) => {
   var body = setHeaders({
     header: {}
   }, userHandle);
@@ -1689,6 +1695,39 @@ const closeVirtualAccount = (userHandle, userPrivateKey, virtualAccountId, accou
   }
   
   return makeRequest("create_test_virtual_account_ach_transaction", body, userPrivateKey);
+};
+
+/**
+ * @param {String} userHandle
+ * @param {String} userPrivateKey
+ * @param {Object} payload
+ * @returns
+ */
+const approveWire = (userHandle, userPrivateKey, payload) => {
+  var body = setHeaders({
+    header: {}
+  }, userHandle);
+  body.transaction_id = payload.transaction_id;
+  body.approve        = payload.approve;
+  body.notes          = payload.notes;
+  body.mock_wire_account_name = payload.mock_wire_account_name;
+  return makeRequest("approve_wire", body, userPrivateKey);
+};
+
+
+/**
+ * @param {String} userHandle
+ * @param {String} userPrivateKey
+ * @param {Object} payload
+ * @returns
+ */
+const mockWireOutFile = (userHandle, userPrivateKey, payload) => {
+  var body = setHeaders({
+    header: {}
+  }, userHandle);
+  body.transaction_id = payload.transaction_id;
+  body.wire_status    = payload.wire_status;
+  return makeRequest("mock_wire_out_file", body, userPrivateKey);
 };
 
 /**
@@ -1820,4 +1859,6 @@ export default {
   retryWebhook,
   closeVirtualAccount,
   createTestVirtualAccountAchTransaction,
+  approveWire,
+  mockWireOutFile
 };

--- a/test/index.js
+++ b/test/index.js
@@ -156,6 +156,8 @@ sardineUser.dateOfBirth = '1990-01-01';
 sardineUser.ssn = '123456222';
 sardineUser.sessionIdentifier = "ppppp-aaaa-dddd-99ce-c45944174e0c";
 
+var mockWireTransactionId_1 = '';
+
 const plaidToken = () => {
     const promise = new Promise((resolve) => {
         const requestBody = {
@@ -192,7 +194,8 @@ const linkCardToken = () => {
     const promise = new Promise((resolve) => {
         const bodyParams = "cBm0RU8eASGfSxLYJjsG73Q\tn9010111999999992\te202205\ts2545";
         const headersObj = {'Content-Type': 'application/tabapay-compact'}
-
+        headersObj['Referer'] = 'https://sso.sandbox.tabapay.com:8443/SSOEvolveISO.html';
+        
         const options = {
             uri: 'https://sso.sandbox.tabapay.com:8443/v2/SSOEncrypt',
             json: false,
@@ -216,6 +219,7 @@ const linkCardToken = () => {
 //const validBusinessUuid = 'dbe721f6-1140-41e3-bdc4-baa632b37405';
 //SANDBOX
 const validBusinessUuid = '9f280665-629f-45bf-a694-133c86bffd5e';
+const wireBusinessUuid = '25e77968-1ca3-4a4b-8e72-506dcac20dc7';
 
 const invalidBusinessUuid = '6d933c10-fa89-41ab-b443-2e78a7cc8cac';
 const issueTransactionDescriptor = 'Issue Trans';
@@ -787,7 +791,7 @@ const issueSilaTests = [
     {
         handle: handles[0],
         key: wallets[0].privateKey,
-        amount: 1000,
+        amount: 50000,
         statusCode: 200,
         expectedResult: 'SUCCESS',
         description: `${handles[0]} should issue sila tokens successfully`,
@@ -805,7 +809,7 @@ const issueSilaTests = [
     {
         handle: handles[0],
         key: wallets[0].privateKey,
-        amount: 100,
+        amount: 50000,
         statusCode: 200,
         descriptor: issueTransactionDescriptor,
         businessUuid: validBusinessUuid,
@@ -1163,6 +1167,17 @@ const redeemSilaTests = [
         description: `${handles[0]} should redeem sila with card name`,
         statusCode: 200,
         expectedResult: 'SUCCESS',
+    },
+    {
+        handle: handles[0],
+        key: wallets[0].privateKey,
+        amount: 11000,
+        processingType: 'WIRE',
+        businessUuid: wireBusinessUuid,
+        description: `${handles[0]} should redeem sila with WIRE processingType`,
+        statusCode: 200,
+        expectedResult: 'SUCCESS',
+        mockWireAccountName:'mock_account_success',
     },
 ];
 
@@ -2434,6 +2449,7 @@ describe('Successful Check KYC', function () {
                 let res = await sila.checkKYC(test.handle, test.key, test.kycLevel);
                 let { statusCode } = res;
                 let { status, message } = res.data;
+
                 while (
                     statusCode === 200 &&
                     status === 'FAILURE' &&
@@ -2442,6 +2458,7 @@ describe('Successful Check KYC', function () {
                 ) {
                     await sleep(30000, test.description); // eslint-disable-line no-await-in-loop
                     res = await sila.checkKYC(test.handle, test.key, test.kycLevel); // eslint-disable-line no-await-in-loop
+
                     ({ statusCode } = res);
                     ({ status, message } = res.data);
                 }
@@ -2936,7 +2953,6 @@ describe('Link Card', function () {
     it("Successfully linked the Card.", async () => {
         try {
             const resToken = await linkCardToken();
-
             const cardObj = {
                 "card_name":"visa",
                 "account_postal_code":"12345",
@@ -2947,7 +2963,6 @@ describe('Link Card', function () {
                 wallets[0].privateKey,
                 cardObj,
             );
-            
             assert.equal(res.statusCode, 200);
             assert.isTrue(res.data.success);
             assert.equal(res.data.status, 'SUCCESS');
@@ -3157,7 +3172,13 @@ describe('Redeem Sila', function () {
                     test.businessUuid,
                     test.processingType,
                     cardName,
+                    test.source_id,
+                    test.destination_id,
+                    test.mockWireAccountName
                 );
+                if (test.processingType == 'WIRE' && !mockWireTransactionId_1) {
+                    mockWireTransactionId_1 = res.data.transaction_id;
+                }
                 
                 if (res.statusCode === 200) redeemReferences.push(res.data.reference);
                 assert.equal(res.statusCode, test.statusCode);
@@ -3170,6 +3191,72 @@ describe('Redeem Sila', function () {
                 assert.fail(e);
             }
         });
+    });
+});
+
+describe('Approve Wire:Approve', function () {
+    this.timeout(300000);
+    it('Successfully approve Wire', async () => {
+        try {
+            var loop_payload = {
+                "handle": handles[0],
+                "search_filters": {
+                    'transaction_id': mockWireTransactionId_1,
+                }
+            };  
+    
+            let transactionRes = await sila.getTransactions(loop_payload.handle, wallets[0].privateKey,loop_payload.search_filters);
+            let { statusCode } = transactionRes;
+            let { success } = transactionRes.data;
+    
+            let { provider_status } = transactionRes.data.transactions[0];
+
+            while (
+                statusCode === 200 &&
+                success &&
+                (provider_status !== 'pending_approval')
+            ) {
+                await sleep(3000, 'Get Transction..');
+                transactionRes = await sila.getTransactions(loop_payload.handle, wallets[0].privateKey,loop_payload.search_filters);
+                ({ statusCode } = transactionRes);
+                ({ success } = transactionRes.data);
+                ({ provider_status} = transactionRes.data.transactions[0]);
+            }
+
+            let payload = {
+                "approve":true,
+                "transaction_id":mockWireTransactionId_1,
+                "notes":null,
+                "mock_wire_account_name":"mock_account_success"
+            }
+            const res = await sila.approveWire(handles[0], wallets[0].privateKey, payload);
+            assert.equal(res.statusCode, 200);
+            assert.isTrue(res.data.success);
+            assert.equal(res.data.status, 'SUCCESS');
+                
+        } catch (e) {
+            assert.fail(e);
+        }
+    });
+});
+
+describe('Mock Wire Out File', function () {
+    this.timeout(300000);
+    it('Successfully update status mock wire out file', async () => {
+        try {
+            await sleep(30000, 'Mock Wire Out File');
+            let payload = {
+                "wire_status":"PR",
+                "transaction_id":mockWireTransactionId_1
+            }
+            const res = await sila.mockWireOutFile(handles[0], wallets[0].privateKey, payload);
+            assert.equal(res.statusCode, 200);
+            assert.isTrue(res.data.success);
+            assert.equal(res.data.status, 'SUCCESS');
+                
+        } catch (e) {
+            assert.fail(e);
+        }
     });
 });
 
@@ -3246,7 +3333,6 @@ describe('Get Virtual Account', function () {
         }
     });
 });
-
 
 describe('Get Virtual Accounts', function () {
     this.timeout(300000);
@@ -3782,7 +3868,6 @@ describe('Test Virtual Account Ach Transaction', function () {
                 wallets[0].privateKey,
                 payload
             );
-            console.log(res)
             assert.equal(res.statusCode, 200);
             assert.isTrue(res.data.success);
             assert.equal(res.data.status, 'SUCCESS');


### PR DESCRIPTION
Enhancements:
- Added sila_available_balance and sila_pending_balance in the response of /get_wallet.  
- Added new input value for processing_type "WIRE" and  a optional input "mock_wire_account_name" in /redeem_sila.
- Added IMAD, OMAD, provider_tx_id and provider_status fields in the response of /get_transactions. 
- Added provider_status field in timeline object in the response of /get_transactions.
- Added new processing type "WIRE" in input field in search_filters in /get_transactions.

New Features:
- Added support for /approve_wire endpoint.
- Added support for /mock_wire_out_file endpoint.