### PR TITLE
Adding type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "nyc": "^15.1.0",
         "plaid": "^2.10.0",
         "prettier": "^2.2.1",
-        "request-promise": "^4.2.6"
+        "request-promise": "^4.2.6",
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/@babel/cli": {
@@ -6173,6 +6174,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -8435,6 +8437,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -9513,6 +9516,19 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17748,6 +17764,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "babel ./src -d ./lib",
+    "build": "babel ./src -d ./lib && npx tsc",
     "lint": "eslint ./src",
     "test": "nyc mocha --require @babel/register --reporter mocha-multi-reporters --reporter-options configFile=config.json",
     "prepublishOnly": "npm run build"
@@ -27,7 +27,8 @@
     "nyc": "^15.1.0",
     "plaid": "^2.10.0",
     "prettier": "^2.2.1",
-    "request-promise": "^4.2.6"
+    "request-promise": "^4.2.6",
+    "typescript": "^4.8.4"
   },
   "nyc": {
     "reporter": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,6 @@
     // only output d.ts files
     "emitDeclarationOnly": true,
     // Types should go into this directory.
-    // Removing this would place the .d.ts files
-    // next to the .js files
     "outDir": "lib",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "lib",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
I've added a tsconfig that generates d.ts files for the JS and tacked it on to the build command in package.json.

Importing Sila from my fork into our backend locally - and types are working beautifully. This gives the SDK much better DX. This is my first time contributing to another codebase, so if I have missed something please let me know and I can fix it.