### PR TITLE
Feature/engrg 5682 normalize keys

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 v1.1.3
 	Enhancements:
-   - Key inputs to sign() are normalized: any superfluous 0x prefixes are removed and a single 0x is ensured prior to signing.
+   - Key inputs to sign() are normalized.
    - CI matrix extended to include Node.js v22 for compatibility verification.
 
 v1.1.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+v1.1.3
+	Enhancements:
+   - Key inputs to sign() are normalized: any superfluous 0x prefixes are removed and a single 0x is ensured prior to signing.
+   - CI matrix extended to include Node.js v22 for compatibility verification.
+
 v1.1.2
 	Enhancements:
 		- Added new option fields doc_type, doc_id, doc_state and doc_country for /register.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ strategy:
   matrix:
     node14:
       nodeVersion: '14.x'
+    node22:
+      nodeVersion: '22.x'
 
 steps:
 - task: NodeTool@0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sila-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "lib/index.js",
   "scripts": {
     "build": "babel ./src -d ./lib",

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,8 @@ const sign = (message, key) => {
     throw new Error('Unable to sign request: keys not set');
   }
   const hash =  ethers.solidityPackedKeccak256(['string'], [message]);
-  const signingKey = new ethers.SigningKey('0x' + key)
+  const normalizeKey = key.startsWith('0x') ? key : '0x' + key;
+  const signingKey = new ethers.SigningKey(normalizeKey)
   const signatureObject = signingKey.sign(hash)
 
   const r = signatureObject.r.slice(2);


### PR DESCRIPTION
ENGRG-5682: Normalize keys for message signing & add Node v22 test

What’s changed

Key normalization: The sign() helper now ensures that the private key string has exactly one 0x prefix before instantiating ethers.SigningKey. This prevents the invalid-BytesLike errors when users include or omit the prefix.

Node v22 compatibility: Added an explicit CI step (and unit test) against Node.js v22 to catch any runtime issues as we upgrade.

Why

Without normalization, passing a key like "0x0x…" would throw invalid BytesLike value. Now both "abcdef…" and "0xabcdef…" are handled gracefully.

We’re preparing our SDK to support the newest Node release, so it’s critical to verify everything still works under v22.